### PR TITLE
Add "link" property to StoredEvent when using resolveLinkTos flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Represents an event as it exists on the Event Store server. Inherits from Event 
 * streamId - The name of the Event Store stream that this event was stored in (string)
 * eventNumber - The sequence number for this event within the stream (number)
 * created - The date that this event was stored in the Event Store (date)
+* link - If event was read from a stream using the resolveLinkTos flag, will contain the original link data (from before the event was resolved.) (StoredEvent)
 
 ## ICredentials interface
 An object containing credentials for access to secured resources.

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Represents an event either before or after it has been stored.
 Represents an event as it exists on the Event Store server. Inherits from Event and adds the following properties:
 
 * streamId - The name of the Event Store stream that this event was stored in (string)
-* number - The sequence number for this event within the stream (number)
+* eventNumber - The sequence number for this event within the stream (number)
 * created - The date that this event was stored in the Event Store (date)
 
 ## ICredentials interface

--- a/event-store-client.d.ts
+++ b/event-store-client.d.ts
@@ -64,7 +64,7 @@ declare module "event-store-client" {
 
 	export interface StoredEvent extends Event {
 		streamId: string;
-		number: number;
+		eventNumber: number;
 		created: Date;
 	}
 

--- a/event-store-client.d.ts
+++ b/event-store-client.d.ts
@@ -66,6 +66,7 @@ declare module "event-store-client" {
 		streamId: string;
 		eventNumber: number;
 		created: Date;
+		link: StoredEvent;
 	}
 
 	export interface IOperationCompleted {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -493,7 +493,9 @@ function unpackResolvedEvent(resolvedEvent) {
     if (!resolvedEvent.event) {
         throw new Error("Not a ResolvedEvent: " + resolvedEvent);
     }
-    return unpackEventRecord(resolvedEvent.event);
+    var unpackedEvent = unpackEventRecord(resolvedEvent.event);
+    if (resolvedEvent.link) unpackedEvent.link = unpackEventRecord(resolvedEvent.link);
+    return unpackedEvent;
 }
 
 function uuidStringFromBuffer(buffer) {


### PR DESCRIPTION
When unpacking an event message that has a defined "link" property (which would be a sibling of the "event" property), create a "link" property in the unpacked StoredEvent to hold the deserialized link information. This "link" would become another StoredEvent instance. 

Such a structure should only exist if the stream was read using the resolveLinkTos flag. 

**NOTE:** I also corrected a small error in the README and the TypeScript defs, which indicated that the "number" property in StoredEvent represents the event number.  Based on what I saw in connection.js, the property is "eventNumber", not "number". 

**Original discussions:**
- Issue #5 
- [Google Groups thread](https://groups.google.com/forum/#!topic/event-store/MIsb87kjvzE)
