### PR TITLE
Dependency update

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,14 +10,14 @@
   },
   "main": "index.js",
   "dependencies": {
-    "protobufjs": "~3.4.0",
+    "protobufjs": "~5.0.1",
     "node-uuid": "~1.4.1",
-    "long": "~2.0.1"
+    "long": "~3.1.0"
   },
   "devDependencies": {
-    "mocha-teamcity-reporter": "0.0.4",
+    "mocha-teamcity-reporter": "~1.0.0",
     "optimist": "~0.6.1",
-    "mocha": "~1.21.4"
+    "mocha": "~2.4.5"
   },
   "scripts": {
     "test": "mocha",


### PR DESCRIPTION
Currently npm (v.3.8.8, node 4.4.3) throws an error when installing this module due to an old dependency:

```
npm WARN install:memcpy@0.5.0 memcpy@0.5.0 install: `node-gyp configure build`
npm WARN install:memcpy@0.5.0 Exit status 1
```

Dependency tree:

```
+-- event-store-client@0.0.6
| +-- long@2.0.1
| `-- protobufjs@3.4.1
|   +-- ascli@0.3.0
|   | +-- colour@0.7.1
|   | `-- optjs@3.2.2
|   `-- bytebuffer@3.2.3
|     +-- bufferview@1.0.1
|     `-- UNMET OPTIONAL DEPENDENCY memcpy@~0.5
```

I updated all dependencies and the tests run fine. Please publish a new version to npm :) 
