### PR TITLE
Feature/3 catch up subscriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,19 @@ Subscribes to a stream to receive notifications as soon as an event is written t
 
 Returns a Buffer containing a GUID that identifies the subscription, for use with unsubscribeStream().
 
+### Connection.subscribeToStreamFrom()
+Executes a catch-up subscription on the given stream, reading events from a given event number, and continuing with a live subscription when all historical events have been read.
+
+* streamId - The name of the stream in the Event Store (string)
+* fromEventNumber - Which event number to start after (if null, then from the beginning of the stream.)
+* credentials - The user name and password needed for permission to subscribe to the stream.
+* onEventAppeared - Callback for each event received (historical or live)
+* onLiveProcessingStarted - Callback when historical events have been read and live events are about to be read.
+* onDropped - Callback when subscription drops or is dropped.
+* settings - Settings for the catch-up subscription.
+
+Returns an instance representing the catch-up subscription (EventStoreStreamCatchUpSubscription).
+
 ### Connection.readAllEventsBackward() / Connection.readAllEventsForward()
 Reads events from across all streams, in order (backward = newest first, forward = oldest first).
 
@@ -130,3 +143,23 @@ Passed to the onConfirmed callback used by subscribeToStream() when a subscripti
 Passed to the onDropped callback used by subscribeToStream() when a subscription terminates, or cannot be established.
 
 * reason - The reason why the subscription was dropped (enumeration, 0 = Unsubscribed, 1 = Access Denied)
+
+## CatchUpSubscriptionSettings class
+A property bag of settings passed when creating a new catch-up subscription.
+
+* maxLiveQueueSize - The maximum amount to buffer when processing from the live subscription.
+* readBatchSize - The number of events to read per batch when reading historical events.
+* debug - True if in debug mode.
+* resolveLinkTos - Whether or not to resolve link events.
+
+## EventStoreStreamCatchUpSubscription class
+Represents a catch-up subscription to a single stream. 
+
+### EventStoreStreamCatchUpSubscription.start()
+Initiate start of the catch-up subscription.
+
+### EventStoreStreamCatchUpSubscription.stop()
+Request to stop the catch-up subscription.
+
+### EventStoreStreamCatchUpSubscription.getCorrelationId()
+Get the subscription ID of the underlying Event Store subscription, in order to pass it back to the Connection object, for example.

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var Connection          = require("./lib/connection"),
+var CatchUpSubscription = require("./lib/CatchUpSubscription"),
+    Connection = require("./lib/connection"),
     Commands            = require("./lib/commands"),
     ExpectedVersion     = require("./lib/expectedVersion"),
     Messages            = require("./lib/messages"),
@@ -7,6 +8,7 @@ var Connection          = require("./lib/connection"),
     ReadStreamResult    = require("./lib/readStreamResult"),
     EventStoreClient    = {};
 
+EventStoreClient.CatchUpSubscription = CatchUpSubscription;
 EventStoreClient.Connection         = Connection;
 EventStoreClient.Commands           = Commands;
 EventStoreClient.ExpectedVersion    = ExpectedVersion;

--- a/lib/catchUpSubscription.js
+++ b/lib/catchUpSubscription.js
@@ -81,6 +81,7 @@
     function EventStoreCatchUpSubscription(connection, streamId, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings) {
         ArgValidator.notNull(connection, 'connection');
         ArgValidator.notNull(eventAppeared, 'eventAppeared');
+        if (!settings) settings = new CatchUpSubscriptionSettings();
 
         this._connection = connection;
         this._streamId = streamId || "";
@@ -116,7 +117,7 @@
     EventStoreCatchUpSubscription.prototype.isSubscribedToAll = function () { return this._streamId.length == 0; };
 
     EventStoreCatchUpSubscription.prototype.start = function () {
-        this._log("Catch-up Subscription to %s: starting...", this.isSubscribedToAll ? "<all>" : this._streamId);
+        this._log("Catch-up Subscription to %s: starting...", this.isSubscribedToAll() ? "<all>" : this._streamId);
         this.runSubscription();
     };
 
@@ -135,6 +136,7 @@
 
     EventStoreCatchUpSubscription.prototype.loadHistoricalEvents = function(callback) {
         this._log("Catch-up Subscription to %s: running...", this.isSubscribedToAll() ? "<all>" : this._streamId);
+        var _this = this;
 
         this._allowProcessing = false;
 
@@ -145,7 +147,7 @@
                 if (err) {
                     if (callback) callback(err);
                 } else {
-                    this.subscribeToStream(callback);
+                    _this.subscribeToStream(callback);
                 }
             });
         } else {
@@ -155,6 +157,8 @@
     };
 
     EventStoreCatchUpSubscription.prototype.subscribeToStream = function(callback) {
+        var _this = this;
+
         if (!this._shouldStop) {
             this._log("Catch-up Subscription to %s: subscribing...", this.isSubscribedToAll() ? "<all>" : this._streamId);
 
@@ -166,12 +170,12 @@
                         this._streamId, this._resolveLinkTos, 
                         this.enqueuePushedEvent.bind(this), 
                         function(confirmation) {
-                            this._subscription = {
+                            _this._subscription = {
                                 correlationId: subscriptionId,
                                 lastCommitPosition: confirmation.last_commit_position,
                                 lastEventNumber: confirmation.last_event_number
                             };
-                            this.readMissedHistoricEvents(callback);
+                            _this.readMissedHistoricEvents(callback);
                         }, 
                         this.serverSubscriptionDropped.bind(this), 
                         this._userCredentials);
@@ -183,6 +187,8 @@
     };
 
     EventStoreCatchUpSubscription.prototype.readMissedHistoricEvents = function (callback) {
+        var _this = this;
+
         if (!this._shouldStop) {
             this._log("Catch-up Subscription to %s: pulling events (if left)...", this.isSubscribedToAll() ? "<all>" : this._streamId);
 
@@ -190,7 +196,7 @@
                 if (err) {
                     if (callback) callback(err);
                 } else {
-                    this.startLiveProcessing(callback);
+                    _this.startLiveProcessing(callback);
                 }
             });
         } else {
@@ -269,8 +275,9 @@
     EventStoreCatchUpSubscription.prototype.dropSubscriptionEvent = function() { return { specialType: 'DropSubscription' }; };
 
     EventStoreCatchUpSubscription.prototype.dropSubscription = function(reason, err) {
-        this._log("Catch-up Subscription to %: dropping subscription, reason: %s %s.",
-                  this.isSubscribedToAll() ? "<all>" : this._streamId, reason, err == null ? "" : err.toString());
+        this._log("Catch-up Subscription to %s: dropping subscription, reason: %s, result: %s, error: %s.",
+                  this.isSubscribedToAll() ? "<all>" : this._streamId, reason,
+                  err == null ? "" : err.result, err == null ? "" : err.error);
 
         if (this._subscription != null) {
             this._connection.unsubscribeFromStream(this._subscription.correlationId, this._userCredentials, function(pkg) {
@@ -337,12 +344,22 @@
                 nextReadEventNumber = (event.link ? event.link.eventNumber : event.eventNumber) + 1;
             },
             this._userCredentials,
-            function (err) {
-                var effectiveErr = err || eventErr;
+            function (completed) {
+                // Check for error.
+                var effectiveErr = eventErr;
+                if (!effectiveErr) {
+                    // Check for error reading events.
+                    if (completed.result != 0) {
+                        effectiveErr = new Error('Error reading stream events: (' + completed.result.toString() + ') ' + completed.error);
+                    }
+                }
+
+                // Act on error.
                 if (effectiveErr) {
                     if (callback) callback(effectiveErr);
                     return;
                 }
+
                 var isEndOfStream = nextReadEventNumber == _this._nextReadEventNumber; // Didn't read any events.
                 var done = lastEventNumber == null ? isEndOfStream : nextReadEventNumber > lastEventNumber;
                 _this._nextReadEventNumber = nextReadEventNumber;
@@ -379,8 +396,8 @@
                 processed = true;
             }
 
-            _this._log("Catch-up Subscription to %s: %s event (%s, %d, %s)",
-                            _this.isSubscribedToAll() ? "<all>" : _this._streamId,
+            this._log("Catch-up Subscription to %s: %s event (%s, %d, %s)",
+                            this.isSubscribedToAll() ? "<all>" : this._streamId,
                             processed ? "processed" : "skipping", 
                             origEvent.streamId, origEvent.eventNumber, origEvent.eventType);
 

--- a/lib/catchUpSubscription.js
+++ b/lib/catchUpSubscription.js
@@ -304,8 +304,6 @@
         this._nextReadEventNumber = ArgValidator.isNumber(fromEventNumberExclusive) ? fromEventNumberExclusive : 0;
     }
     
-    // START HERE: do rest of the methods in subclass
-
     /*
     Child class notes:
 
@@ -316,8 +314,40 @@
     // Wire prototypal inheritance.
     Object.setPrototypeOf(EventStoreStreamCatchUpSubscription.prototype, EventStoreCatchUpSubscription.prototype);
 
+    /**
+     * Read events until the given event number async.
+     * 
+     * @param {number} lastCommitPosition The commit position to read until.
+     * @param {number} lastEventNumber The event number to read until.
+     */
+    EventStoreStreamCatchUpSubscription.prototype.readEventsTill = function (lastCommitPosition, lastEventNumber, callback) {
+        var nextReadEventNumber = this._nextReadEventNumber;
+
+        this._connection.readStreamEventsForward(
+            this._streamId, this._nextReadEventNumber, this.readBatchSize, this._resolveLinkTos, false,
+            function (event) {
+                this.tryProcess(event);
+                nextReadEventNumber = (event.link ? event.link.eventNumber : event.eventNumber) + 1;
+            },
+            this._userCredentials,
+            function (err) {
+                if (err) {
+                    if (callback) callback(err);
+                    return;
+                }
+                var isEndOfStream = nextReadEventNumber == this._nextReadEventNumber; // Didn't read any events.
+                var done = lastEventNumber == null ? isEndOfStream : nextReadEventNumber > lastEventNumber;
+                this._nextReadEventNumber = nextReadEventNumber;
+
+                // START HERE
+                // Handle flushing server events - if !done and atEndOfStream, sleep 1 ms before next, else next
+                // Put here: starting at line 538 EventStoreCatchUpSubscription.cs
+            });
+    };
+
     // EXPOSE public types.
     catchUpSubscription.Settings = CatchUpSubscriptionSettings;
+    catchUpSubscription.Stream = EventStoreStreamCatchUpSubscription;
 
 })(module.exports);
 

--- a/lib/catchUpSubscription.js
+++ b/lib/catchUpSubscription.js
@@ -72,7 +72,7 @@
      * @constructor
      * @param {Connection} connection The connection to Event Store
      * @param {string} streamId The stream name (only if subscribing to a single stream)
-     * @param userCredentials User credentials for the operations.
+     * @param {ICredentials} userCredentials User credentials for the operations.
      * @param {function} eventAppeared Callback for each event received
      * @param {function} liveProcessingStarted Callback when read history phase finishes.
      * @param {function} subscriptionDropped Callback when subscription drops or is dropped.
@@ -307,8 +307,8 @@
      * @constructor
      * @param {Connection} connection The connection to Event Store
      * @param {string} streamId The stream name (only if subscribing to a single stream)
-     * @param {number} fromEventNumberExclusive Which event number to start from (if null, then from the beginning of the stream.)
-     * @param userCredentials User credentials for the operations.
+     * @param {number} fromEventNumberExclusive Which event number to start after (if null, then from the beginning of the stream.)
+     * @param {ICredentials} userCredentials User credentials for the operations.
      * @param {function} eventAppeared Callback for each event received
      * @param {function} liveProcessingStarted Callback when read history phase finishes.
      * @param {function} subscriptionDropped Callback when subscription drops or is dropped.

--- a/lib/catchUpSubscription.js
+++ b/lib/catchUpSubscription.js
@@ -106,6 +106,10 @@
         if (this.debug) console.log.apply(console, arguments);
     };
 
+    EventStoreCatchUpSubscription.prototype.getCorrelationId = function () {
+        return this._subscription ? this._subscription.correlationId : null;
+    };
+
     /**
      * Indicates whether the subscription is to all events or to a specific stream.
      */

--- a/lib/catchUpSubscription.js
+++ b/lib/catchUpSubscription.js
@@ -278,11 +278,12 @@
         }
     };
 
-    /*
-    function EventStoreAllCatchUpSubscription {
-        // NOT IMPLEMENTED because there is no connection.subscribeToAll yet...
+    function EventStoreAllCatchUpSubscription() {
+        throw new Error("NOT IMPLEMENTED: there is not yet any connection.subscribeToAll.")
     }
-    */
+    
+    // Wire up prototypal inheritance.
+    Object.setPrototypeOf(EventStoreAllCatchUpSubscription.prototype, EventStoreCatchUpSubscription.prototype);
 
     /**
      * Catch-up subscription for one stream.
@@ -376,6 +377,7 @@
     // EXPOSE public types.
     catchUpSubscription.Settings = CatchUpSubscriptionSettings;
     catchUpSubscription.Stream = EventStoreStreamCatchUpSubscription;
+    catchUpSubscription.All = EventStoreAllCatchUpSubscription; // WARNING: NOT IMPLEMENTED - will throw exception when used.
 
 })(module.exports);
 

--- a/lib/catchUpSubscription.js
+++ b/lib/catchUpSubscription.js
@@ -12,6 +12,9 @@
  * 
  * - No reconnect handling. The Connection object in this Node client currently does not emit anything like a Connect 
  *   event, so there is no way to hook into such an occurrence. 
+ * 
+ * - Handles event processing in the main thread, following Node's convention of async/single-threaded execution, 
+ *   expecting good async, non-blocking behavior from any client using this package. 
  */
 
 (function (catchUpSubscription) {

--- a/lib/catchUpSubscription.js
+++ b/lib/catchUpSubscription.js
@@ -209,10 +209,10 @@
     };
 
     EventStoreCatchUpSubscription.prototype.enqueuePushedEvent = function(event) {
-        var refEvent = event.link || event;
+        var origEvent = event.link || event;
         this._log("Catch-up Subscription to %s: event appeared (%s, %d, %s).",
                     this.isSubscribedToAll() ? "<all>" : this._streamId,
-                    refEvent.streamId, refEvent.eventNumber, refEvent.eventType);
+                    origEvent.streamId, origEvent.eventNumber, origEvent.eventType);
 
         if (this._liveQueue.length >= this.maxPushQueueSize) {
             this.enqueueSubscriptionDropNotification('ProcessingQueueOverflow');
@@ -303,15 +303,8 @@
         this._lastProcessedEventNumber = ArgValidator.isNumber(fromEventNumberExclusive) ? fromEventNumberExclusive : -1;
         this._nextReadEventNumber = ArgValidator.isNumber(fromEventNumberExclusive) ? fromEventNumberExclusive : 0;
     }
-    
-    /*
-    Child class notes:
 
-    readEventsTill(lastCommitPosition, lastEventNumber)
-    tryProcess(event)
-    */
-
-    // Wire prototypal inheritance.
+    // Wire up prototypal inheritance.
     Object.setPrototypeOf(EventStoreStreamCatchUpSubscription.prototype, EventStoreCatchUpSubscription.prototype);
 
     /**
@@ -322,11 +315,12 @@
      */
     EventStoreStreamCatchUpSubscription.prototype.readEventsTill = function (lastCommitPosition, lastEventNumber, callback) {
         var nextReadEventNumber = this._nextReadEventNumber;
+        var _this = this;
 
         this._connection.readStreamEventsForward(
             this._streamId, this._nextReadEventNumber, this.readBatchSize, this._resolveLinkTos, false,
             function (event) {
-                this.tryProcess(event);
+                _this.tryProcess(event);
                 nextReadEventNumber = (event.link ? event.link.eventNumber : event.eventNumber) + 1;
             },
             this._userCredentials,
@@ -335,14 +329,45 @@
                     if (callback) callback(err);
                     return;
                 }
-                var isEndOfStream = nextReadEventNumber == this._nextReadEventNumber; // Didn't read any events.
+                var isEndOfStream = nextReadEventNumber == _this._nextReadEventNumber; // Didn't read any events.
                 var done = lastEventNumber == null ? isEndOfStream : nextReadEventNumber > lastEventNumber;
-                this._nextReadEventNumber = nextReadEventNumber;
+                _this._nextReadEventNumber = nextReadEventNumber;
 
-                // START HERE
-                // Handle flushing server events - if !done and atEndOfStream, sleep 1 ms before next, else next
-                // Put here: starting at line 538 EventStoreCatchUpSubscription.cs
+                if (!done && !_this._shouldStop) {
+                    setTimeout(
+                        function () {
+                            _this.readEventsTill(lastCommitPosition, lastEventNumber, callback);
+                        },
+                        isEndOfStream ? 1 : 0  // Waiting for server to flush its data...
+                    );
+                } else {
+                    _this._log("Catch-up Subscription to %s: finished reading events, nextReadEventNumber = %d.",
+                        _this.isSubscribedToAll() ? "<all>" : _this._streamId, _this._nextReadEventNumber);
+
+                    if (callback) callback();
+                }
             });
+    };
+
+    /**
+     * Try to process a single resolved event.
+     * 
+     * @param event The resolved event to process.
+     */
+    EventStoreStreamCatchUpSubscription.prototype.tryProcess = function (event) {
+        var origEvent = event.link || event;
+        var processed = false;
+
+        if (origEvent.eventNumber > this._lastProcessedEventNumber) {
+            this.eventAppeared(event);
+            this._lastProcessedEventNumber = origEvent.eventNumber;
+            processed = true;
+        }
+
+        _this._log("Catch-up Subscription to %s: %s event (%s, %d, %s)",
+                        _this.isSubscribedToAll() ? "<all>" : _this._streamId,
+                        processed ? "processed" : "skipping", 
+                        origEvent.streamId, origEvent.eventNumber, origEvent.eventType);
     };
 
     // EXPOSE public types.

--- a/lib/catchUpSubscription.js
+++ b/lib/catchUpSubscription.js
@@ -84,7 +84,7 @@
 
         this._connection = connection;
         this._streamId = streamId || "";
-        this._resolveLinkTos = _resolveLinkTos;
+        this._resolveLinkTos = settings.resolveLinkTos;
         this._userCredentials = userCredentials;
         this.readBatchSize = settings.readBatchSize;
         this.maxPushQueueSize = settings.maxLiveQueueSize;
@@ -320,17 +320,23 @@
     EventStoreStreamCatchUpSubscription.prototype.readEventsTill = function (lastCommitPosition, lastEventNumber, callback) {
         var nextReadEventNumber = this._nextReadEventNumber;
         var _this = this;
+        var eventErr = null;
 
         this._connection.readStreamEventsForward(
             this._streamId, this._nextReadEventNumber, this.readBatchSize, this._resolveLinkTos, false,
             function (event) {
-                _this.tryProcess(event);
+                _this.tryProcess(event, function (err) {
+                    if (err && !eventErr) {
+                        eventErr = err;
+                    }
+                });
                 nextReadEventNumber = (event.link ? event.link.eventNumber : event.eventNumber) + 1;
             },
             this._userCredentials,
             function (err) {
-                if (err) {
-                    if (callback) callback(err);
+                var effectiveErr = err || eventErr;
+                if (effectiveErr) {
+                    if (callback) callback(effectiveErr);
                     return;
                 }
                 var isEndOfStream = nextReadEventNumber == _this._nextReadEventNumber; // Didn't read any events.
@@ -358,20 +364,27 @@
      * 
      * @param event The resolved event to process.
      */
-    EventStoreStreamCatchUpSubscription.prototype.tryProcess = function (event) {
+    EventStoreStreamCatchUpSubscription.prototype.tryProcess = function (event, callback) {
         var origEvent = event.link || event;
         var processed = false;
 
-        if (origEvent.eventNumber > this._lastProcessedEventNumber) {
-            this.eventAppeared(event);
-            this._lastProcessedEventNumber = origEvent.eventNumber;
-            processed = true;
-        }
+        try {
+            if (origEvent.eventNumber > this._lastProcessedEventNumber) {
+                this.eventAppeared(event);
+                this._lastProcessedEventNumber = origEvent.eventNumber;
+                processed = true;
+            }
 
-        _this._log("Catch-up Subscription to %s: %s event (%s, %d, %s)",
-                        _this.isSubscribedToAll() ? "<all>" : _this._streamId,
-                        processed ? "processed" : "skipping", 
-                        origEvent.streamId, origEvent.eventNumber, origEvent.eventType);
+            _this._log("Catch-up Subscription to %s: %s event (%s, %d, %s)",
+                            _this.isSubscribedToAll() ? "<all>" : _this._streamId,
+                            processed ? "processed" : "skipping", 
+                            origEvent.streamId, origEvent.eventNumber, origEvent.eventType);
+
+            if (callback) callback();
+        }
+        catch (err) {
+            if (callback) callback(err);
+        }
     };
 
     // EXPOSE public types.

--- a/lib/catchUpSubscription.js
+++ b/lib/catchUpSubscription.js
@@ -1,0 +1,323 @@
+﻿/**
+ * This module is a port of the catch-up subscription functionality from 
+ * Event Store's official .NET client. Primarily, it's a port of the C# module 
+ * EventStoreCatchUpSubscription: https://github.com/EventStore/EventStore/blob/release-v3.7.0/src/EventStore.ClientAPI/EventStoreCatchUpSubscription.cs
+ * 
+ * NOTABLE DIFFERENCES
+ * 
+ * - Instead of passing a logger object and a Verbose flag, we accept a simple debug flag, which, if 
+ *   set to true, will cause console log messages to be written in the places where the C# client would have 
+ *   written to the logger (verbose mode or no). This behavior more closely matches that of the existing Node 
+ *   client so far.
+ * 
+ * - No reconnect handling. The Connection object in this Node client currently does not emit anything like a Connect 
+ *   event, so there is no way to hook into such an occurrence. 
+ */
+
+(function (catchUpSubscription) {
+    
+    var ArgValidator = require('argument-validator');
+
+    // CONSTANTS
+    const DefaultReadBatchSize = 500;
+    const MaxReadSize = 4096;
+    const DefaultMaxPushQueueSize = 10000;
+
+    /**
+     * Settings for <tt>EventStoreCatchUpSubscription</tt>
+     * 
+     * @constructor
+     * @param {number} maxLiveQueueSize The max amount to buffer when processing from live subscription. 
+     * @param {number} readBatchSize The number of events to read per batch when reading history
+     * @param {boolean} debug True iff in debug mode
+     * @param {boolean} resolveLinkTos Whether or not to resolve link events 
+     */
+    function CatchUpSubscriptionSettings(maxLiveQueueSize, readBatchSize, debug, resolveLinkTos) {
+        // Validate arguments (supplying defaults where arguments are null or missing). 
+        if (arguments.length < 4 || resolveLinkTos == null) {
+            resolveLinkTos = false;
+        } else {
+            ArgValidator.boolean(resolveLinkTos, 'resolveLinkTos');
+        }
+        if (arguments.length < 3 || debug == null) {
+            debug = false;
+        } else {
+            ArgValidator.boolean(debug, 'debug');
+        }
+        if (arguments.length < 2 || readBatchSize == null) {
+            readBatchSize = DefaultReadBatchSize;
+        } else {
+            ArgValidator.number(readBatchSize, 'readBatchSize');
+        }
+        if (arguments.length < 1 || maxLiveQueueSize == null) {
+            maxLiveQueueSize = DefaultMaxPushQueueSize;
+        } else {
+            ArgValidator.number(maxLiveQueueSize, 'maxLiveQueueSize');
+        }
+
+        if (readBatchSize > MaxReadSize) throw new Error("Read batch size should be less than " + MaxReadSize.toString() + ". For larger reads you should page.");
+
+        this.maxLiveQueueSize = maxLiveQueueSize;
+        this.readBatchSize = readBatchSize;
+        this.debug = debug;
+        this.resolveLinkTos = resolveLinkTos;
+    }
+
+    /**
+     * Base class representing catch-up subscriptions.
+     * 
+     * @constructor
+     * @param {Connection} connection The connection to Event Store
+     * @param {string} streamId The stream name (only if subscribing to a single stream)
+     * @param userCredentials User credentials for the operations.
+     * @param {function} eventAppeared Callback for each event received
+     * @param {function} liveProcessingStarted Callback when read history phase finishes.
+     * @param {function} subscriptionDropped Callback when subscription drops or is dropped.
+     * @param {CatchUpSubscriptionSettings} settings Settings for this subscription.
+     */
+    function EventStoreCatchUpSubscription(connection, streamId, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings) {
+        ArgValidator.notNull(connection, 'connection');
+        ArgValidator.notNull(eventAppeared, 'eventAppeared');
+
+        this._connection = connection;
+        this._streamId = streamId || "";
+        this._resolveLinkTos = _resolveLinkTos;
+        this._userCredentials = userCredentials;
+        this.readBatchSize = settings.readBatchSize;
+        this.maxPushQueueSize = settings.maxLiveQueueSize;
+        this.eventAppeared = eventAppeared;
+        this._liveProcessingStarted = liveProcessingStarted;
+        this._subscriptionDropped = subscriptionDropped;
+        this.debug = settings.debug;
+        this._shouldStop = false;
+        this._dropData = null;
+        this._liveQueue = [];
+        this._allowProcessing = false;
+        this._subscription = null;
+    }
+
+    /**
+     * Accept parameters to pass on to console.log. 
+     */
+    EventStoreCatchUpSubscription.prototype._log = function () {
+        if (this.debug) console.log.apply(console, arguments);
+    };
+
+    /**
+     * Indicates whether the subscription is to all events or to a specific stream.
+     */
+    EventStoreCatchUpSubscription.prototype.isSubscribedToAll = function () { return this._streamId.length == 0; };
+
+    EventStoreCatchUpSubscription.prototype.start = function () {
+        this._log("Catch-up Subscription to %s: starting...", this.isSubscribedToAll ? "<all>" : this._streamId);
+        this.runSubscription();
+    };
+
+    /**
+     * Attempts to stop the subscription without blocking for completion of stop
+     */
+    EventStoreCatchUpSubscription.prototype.stop = function() {
+        this._log("Catch-up Subscription to %s: requesting stop...", this.isSubscribedToAll() ? "<all>" : this._streamId);
+        this._shouldStop = true;
+        this.enqueueSubscriptionDropNotification('UserInitiated', null);
+    };
+    
+    EventStoreCatchUpSubscription.prototype.runSubscription = function () {
+        this.loadHistoricalEvents(this.handleError.bind(this));
+    };
+
+    EventStoreCatchUpSubscription.prototype.loadHistoricalEvents = function(callback) {
+        this._log("Catch-up Subscription to %s: running...", this.isSubscribedToAll() ? "<all>" : this._streamId);
+
+        this._allowProcessing = false;
+
+        if (!this._shouldStop) {
+            this._log("Catch-up Subscription to %s: pulling events...", this.isSubscribedToAll() ? "<all>" : this._streamId);
+
+            this.readEventsTill(null, null, function(err) {
+                if (err) {
+                    if (callback) callback(err);
+                } else {
+                    this.subscribeToStream(callback);
+                }
+            });
+        } else {
+            this.dropSubscription('UserInitiated');
+            if (callback) callback();
+        }
+    };
+
+    EventStoreCatchUpSubscription.prototype.subscribeToStream = function(callback) {
+        if (!this._shouldStop) {
+            this._log("Catch-up Subscription to %s: subscribing...", this.isSubscribedToAll() ? "<all>" : this._streamId);
+
+            if (this.isSubscribedToAll()) {
+                callback(new Error('Cannot do catch-up subscription to all at this time. Not implemented: connection.subscribeToAll'));
+            } else {
+                var subscriptionId = 
+                    this._connection.subscribeToStream(
+                        this._streamId, this._resolveLinkTos, 
+                        this.enqueuePushedEvent.bind(this), 
+                        function(confirmation) {
+                            this._subscription = {
+                                correlationId: subscriptionId,
+                                lastCommitPosition: confirmation.last_commit_position,
+                                lastEventNumber: confirmation.last_event_number
+                            };
+                            this.readMissedHistoricEvents(callback);
+                        }, 
+                        this.serverSubscriptionDropped.bind(this), 
+                        this._userCredentials);
+            }
+        } else {
+            this.dropSubscription('UserInitiated');
+            if (callback) callback();
+        }
+    };
+
+    EventStoreCatchUpSubscription.prototype.readMissedHistoricEvents = function (callback) {
+        if (!this._shouldStop) {
+            this._log("Catch-up Subscription to %s: pulling events (if left)...", this.isSubscribedToAll() ? "<all>" : this._streamId);
+
+            this.readEventsTill(this._subscription.lastCommitPosition, this._subscription.lastEventNumber, function (err) {
+                if (err) {
+                    if (callback) callback(err);
+                } else {
+                    this.startLiveProcessing(callback);
+                }
+            });
+        } else {
+            this.dropSubscription('UserInitiated');
+            if (callback) callback();
+        }
+    };
+
+    EventStoreCatchUpSubscription.prototype.startLiveProcessing = function (callback) {
+        if (this._shouldStop) {
+            this.dropSubscription('UserInitiated');
+            if (callback) callback();
+            return;
+        }
+
+        this._log("Catch-up Subscription to %s: processing live events...", this.isSubscribedToAll() ? "<all>" : this._streamId);
+
+        if (this._liveProcessingStarted) this._liveProcessingStarted();
+
+        this._allowProcessing = true;
+        this.processLiveQueue();
+        if (callback) callback();
+    };
+
+    EventStoreCatchUpSubscription.prototype.enqueuePushedEvent = function(event) {
+        var refEvent = event.link || event;
+        this._log("Catch-up Subscription to %s: event appeared (%s, %d, %s).",
+                    this.isSubscribedToAll() ? "<all>" : this._streamId,
+                    refEvent.streamId, refEvent.eventNumber, refEvent.eventType);
+
+        if (this._liveQueue.length >= this.maxPushQueueSize) {
+            this.enqueueSubscriptionDropNotification('ProcessingQueueOverflow');
+            return;
+        }
+
+        this._liveQueue.push(event);
+
+        if (this._allowProcessing) this.processLiveQueue();
+    };
+
+    EventStoreCatchUpSubscription.prototype.serverSubscriptionDropped = function(dropped) {
+        this.enqueueSubscriptionDropNotification(dropped.reason);
+    };
+
+    EventStoreCatchUpSubscription.prototype.enqueueSubscriptionDropNotification = function(reason, err) {
+        // if drop data was already set -- no need to enqueue drop again, somebody did that already
+        if (this._dropData == null) {
+            this._dropData = { reason: reason, error: err };
+            this._liveQueue.push(this.dropSubscriptionEvent());
+            if (_allowProcessing) this.processLiveQueue();
+        }
+    };
+
+    EventStoreCatchUpSubscription.prototype.handleError = function(err) {
+        if (err) {
+            this.dropSubscription('CatchUpError', err);
+        }
+    };
+
+    EventStoreCatchUpSubscription.prototype.processLiveQueue = function() {
+        var e;
+        while (e = this._liveQueue.shift()) {
+            if (e.specialType == 'DropSubscription') {
+                if (this._dropData == null) this._dropData = { reason: 'Unknown', error: new Error('Drop reason not specified') };
+                this.dropSubscription(this._dropData.reason, this._dropData.error);
+                return;
+            }
+            this.tryProcess(e, function(err) {
+                if (err) {
+                    this.dropSubscription('EventHandlerException', err);
+                }
+            });
+        }
+    };
+
+    EventStoreCatchUpSubscription.prototype.dropSubscriptionEvent = function() { return { specialType: 'DropSubscription' }; };
+
+    EventStoreCatchUpSubscription.prototype.dropSubscription = function(reason, err) {
+        this._log("Catch-up Subscription to %: dropping subscription, reason: %s %s.",
+                  this.isSubscribedToAll() ? "<all>" : this._streamId, reason, err == null ? "" : err.toString());
+
+        if (this._subscription != null) {
+            this._connection.unsubscribeFromStream(this._subscription.correlationId, this._userCredentials, function(pkg) {
+                this._subscription = null;
+                if (this._subscriptionDropped) {
+                    this._subscriptionDropped(this, reason, err);
+                }
+            });
+        }
+    };
+
+    /*
+    function EventStoreAllCatchUpSubscription {
+        // NOT IMPLEMENTED because there is no connection.subscribeToAll yet...
+    }
+    */
+
+    /**
+     * Catch-up subscription for one stream.
+     * 
+     * @constructor
+     * @param {Connection} connection The connection to Event Store
+     * @param {string} streamId The stream name (only if subscribing to a single stream)
+     * @param {number} fromEventNumberExclusive Which event number to start from (if null, then from the beginning of the stream.)
+     * @param userCredentials User credentials for the operations.
+     * @param {function} eventAppeared Callback for each event received
+     * @param {function} liveProcessingStarted Callback when read history phase finishes.
+     * @param {function} subscriptionDropped Callback when subscription drops or is dropped.
+     * @param {CatchUpSubscriptionSettings} settings Settings for this subscription.
+     */
+    function EventStoreStreamCatchUpSubscription(connection, streamId, fromEventNumberExclusive, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings) {
+        // Base class constructor (JS-style).
+        EventStoreCatchUpSubscription.call(this, connection, streamId, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings);
+
+        ArgValidator.notNull(streamId, 'streamId');
+
+        this._lastProcessedEventNumber = ArgValidator.isNumber(fromEventNumberExclusive) ? fromEventNumberExclusive : -1;
+        this._nextReadEventNumber = ArgValidator.isNumber(fromEventNumberExclusive) ? fromEventNumberExclusive : 0;
+    }
+    
+    // START HERE: do rest of the methods in subclass
+
+    /*
+    Child class notes:
+
+    readEventsTill(lastCommitPosition, lastEventNumber)
+    tryProcess(event)
+    */
+
+    // Wire prototypal inheritance.
+    Object.setPrototypeOf(EventStoreStreamCatchUpSubscription.prototype, EventStoreCatchUpSubscription.prototype);
+
+    // EXPOSE public types.
+    catchUpSubscription.Settings = CatchUpSubscriptionSettings;
+
+})(module.exports);
+

--- a/lib/catchUpSubscription.js
+++ b/lib/catchUpSubscription.js
@@ -246,7 +246,7 @@
         if (this._dropData == null) {
             this._dropData = { reason: reason, error: err };
             this._liveQueue.push(this.dropSubscriptionEvent());
-            if (_allowProcessing) this.processLiveQueue();
+            if (this._allowProcessing) this.processLiveQueue();
         }
     };
 
@@ -258,6 +258,8 @@
 
     EventStoreCatchUpSubscription.prototype.processLiveQueue = function() {
         var e;
+        var _this = this;
+
         while (e = this._liveQueue.shift()) {
             if (e.specialType == 'DropSubscription') {
                 if (this._dropData == null) this._dropData = { reason: 'Unknown', error: new Error('Drop reason not specified') };
@@ -266,7 +268,7 @@
             }
             this.tryProcess(e, function(err) {
                 if (err) {
-                    this.dropSubscription('EventHandlerException', err);
+                    _this.dropSubscription('EventHandlerException', err);
                 }
             });
         }
@@ -275,17 +277,20 @@
     EventStoreCatchUpSubscription.prototype.dropSubscriptionEvent = function() { return { specialType: 'DropSubscription' }; };
 
     EventStoreCatchUpSubscription.prototype.dropSubscription = function(reason, err) {
+        var _this = this;
         this._log("Catch-up Subscription to %s: dropping subscription, reason: %s, result: %s, error: %s.",
                   this.isSubscribedToAll() ? "<all>" : this._streamId, reason,
                   err == null ? "" : err.result, err == null ? "" : err.error);
 
         if (this._subscription != null) {
-            this._connection.unsubscribeFromStream(this._subscription.correlationId, this._userCredentials, function(pkg) {
-                this._subscription = null;
-                if (this._subscriptionDropped) {
-                    this._subscriptionDropped(this, reason, err);
+            this._connection.unsubscribeFromStream(this._subscription.correlationId, this._userCredentials, function (pkg) {
+                _this._subscription = null;
+                if (_this._subscriptionDropped) {
+                    _this._subscriptionDropped(_this, reason, err);
                 }
             });
+        } else if (this._subscriptionDropped) {
+            _this._subscriptionDropped(_this, reason, err);
         }
     };
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -273,17 +273,17 @@ Connection.prototype.unsubscribeFromStream = function(correlationId, credentials
 /**
      * Initiate catch-up subscription for one stream.
      * 
-     * @param {string} streamName The stream name (only if subscribing to a single stream)
-     * @param {number} fromEventNumber Which event number to start from (if null, then from the beginning of the stream.)
-     * @param userCredentials User credentials for the operations.
-     * @param {function} eventAppeared Callback for each event received
-     * @param {function} liveProcessingStarted Callback when read history phase finishes.
-     * @param {function} subscriptionDropped Callback when subscription drops or is dropped.
+     * @param {string} streamId The stream ID (only if subscribing to a single stream)
+     * @param {number} fromEventNumber Which event number to start after (if null, then from the beginning of the stream.)
+     * @param {ICredentials} credentials User credentials for the operations.
+     * @param {function} onEventAppeared Callback for each event received
+     * @param {function} onLiveProcessingStarted Callback when read history phase finishes.
+     * @param {function} onDropped Callback when subscription drops or is dropped.
      * @param {CatchUpSubscriptionSettings} settings Settings for this subscription.
      */
-Connection.prototype.subscribeToStreamFrom = function (streamName, fromEventNumber, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings) {
+Connection.prototype.subscribeToStreamFrom = function (streamId, fromEventNumber, credentials, onEventAppeared, onLiveProcessingStarted, onDropped, settings) {
     if (!settings) settings = new CatchUpSubscription.Settings();
-    var subscription = new CatchUpSubscription.Stream(this, streamName, fromEventNumber, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings);
+    var subscription = new CatchUpSubscription.Stream(this, streamId, fromEventNumber, credentials, onEventAppeared, onLiveProcessingStarted, onDropped, settings);
     subscription.start();
     return subscription;
 };

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,6 +1,7 @@
 var net                 = require("net");
 var uuid                = require('node-uuid');
 
+var CatchUpSubscription = require("./catchUpSubscription");
 var Messages            = require("./messages");
 var Commands            = require("./commands");
 var OperationResult     = require("./operationResult");
@@ -267,6 +268,22 @@ Connection.prototype.unsubscribeFromStream = function(correlationId, credentials
   var unsubscribeRequest = new Messages.UnsubscribeFromStream();
   var data = unsubscribeRequest.encode().toBuffer();
   this.sendMessage(correlationId, Commands.UnsubscribeFromStream, credentials, data, callback);
+};
+
+/**
+     * Initiate catch-up subscription for one stream.
+     * 
+     * @param {string} streamName The stream name (only if subscribing to a single stream)
+     * @param {number} fromEventNumber Which event number to start from (if null, then from the beginning of the stream.)
+     * @param userCredentials User credentials for the operations.
+     * @param {function} eventAppeared Callback for each event received
+     * @param {function} liveProcessingStarted Callback when read history phase finishes.
+     * @param {function} subscriptionDropped Callback when subscription drops or is dropped.
+     * @param {CatchUpSubscriptionSettings} settings Settings for this subscription.
+     */
+Connection.prototype.subscribeToStreamFrom = function (streamName, fromEventNumber, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings) {
+    if (!settings) settings = new CatchUpSubscription.Settings();
+    return CatchUpSubscription.Stream(this, streamName, fromEventNumber, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings);
 };
 
 Connection.prototype.deleteStream = function(streamId, expectedVersion, requireMaster, hardDelete, credentials, callback) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -283,7 +283,9 @@ Connection.prototype.unsubscribeFromStream = function(correlationId, credentials
      */
 Connection.prototype.subscribeToStreamFrom = function (streamName, fromEventNumber, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings) {
     if (!settings) settings = new CatchUpSubscription.Settings();
-    return CatchUpSubscription.Stream(this, streamName, fromEventNumber, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings);
+    var subscription = new CatchUpSubscription.Stream(this, streamName, fromEventNumber, userCredentials, eventAppeared, liveProcessingStarted, subscriptionDropped, settings);
+    subscription.start();
+    return subscription;
 };
 
 Connection.prototype.deleteStream = function(streamId, expectedVersion, requireMaster, hardDelete, credentials, callback) {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "dependencies": {
     "protobufjs": "~3.4.0",
     "node-uuid": "~1.4.1",
-    "long": "~2.0.1"
+    "long": "~2.0.1",
+    "argument-validator": "^0.1.0"
   },
   "devDependencies": {
     "mocha-teamcity-reporter": "0.0.4",

--- a/test/catchUpSubscription.js
+++ b/test/catchUpSubscription.js
@@ -1,0 +1,50 @@
+var assert = require("assert");
+
+var EventStoreClient = require("../index.js");
+
+var dbconn = require("./common/dbconn");
+var testData = require("./common/testData");
+var defaultHostName = dbconn.defaultHostName;
+var credentials = dbconn.credentials;
+
+describe('Catch-Up Subscription', function() {
+    var testStreams = [];
+
+    context('setting up basic subscription', function () {
+        it('should succeed', function (done) {
+            dbconn.open(done, function (connection) {
+                var actualEventNumbers = [];
+                var streamName = testData.randomStreamName();
+                testStreams.push(streamName);
+
+                var settings = new EventStoreClient.CatchUpSubscription.Settings();
+                
+                testData.writeEvents(
+                    connection, credentials, streamName, 10,
+                    testData.fooEvent,
+                    function () {
+                        connection.subscribeToStreamFrom(
+                            streamName, 6, credentials,
+                            function (event) {
+                                actualEventNumbers.push(event.eventNumber);
+                            },
+                            function () {
+                                assert.deepEqual(actualEventNumbers, [7, 8, 9]);
+                                done();
+                            },
+                            function () {
+                                assert.fail(null, null, 'Subscription dropped!');
+                                done;
+                            },
+                            settings);
+                    });
+            });
+        });
+    });
+
+    after(function () {
+        dbconn.open(null, function (connection) {
+            testData.deleteTestStreams(connection, credentials, testStreams);
+        });
+    });
+});

--- a/test/catchUpSubscription.js
+++ b/test/catchUpSubscription.js
@@ -34,9 +34,130 @@ describe('Catch-Up Subscription', function() {
                             },
                             function () {
                                 assert.fail(null, null, 'Subscription dropped!');
-                                done;
+                                done();
                             },
                             settings);
+                    });
+            });
+        });
+
+        it('can process additional events live', function (done) {
+            dbconn.open(done, function (connection) {
+                var actualEventNumbers = [];
+                var liveProcessingStarted = false;
+                var streamName = testData.randomStreamName();
+                testStreams.push(streamName);
+
+                var settings = new EventStoreClient.CatchUpSubscription.Settings();
+
+                testData.writeEvents(
+                    connection, credentials, streamName, 10,
+                    testData.fooEvent,
+                    function () {
+                        connection.subscribeToStreamFrom(
+                            streamName, 6, credentials,
+                            function (event) {
+                                actualEventNumbers.push(event.eventNumber);
+
+                                if (liveProcessingStarted && event.eventNumber >= 12) {
+                                    assert.deepEqual(actualEventNumbers, [7, 8, 9, 10, 11, 12]);
+                                    done();
+                                }
+                            },
+                            function () {
+                                liveProcessingStarted = true;
+                                testData.writeEvents(
+                                    connection, credentials, streamName, 3,
+                                    testData.fooEvent,
+                                    function () {});
+                            },
+                            null,
+                            settings);
+                    });
+            });
+        });
+
+        it('should succeed when reading events in small pages', function (done) {
+            dbconn.open(done, function (connection) {
+                var actualEventNumbers = [];
+                var streamName = testData.randomStreamName();
+                testStreams.push(streamName);
+
+                var settings = new EventStoreClient.CatchUpSubscription.Settings();
+                settings.readBatchSize = 2;
+
+                testData.writeEvents(
+                    connection, credentials, streamName, 10,
+                    testData.fooEvent,
+                    function () {
+                        connection.subscribeToStreamFrom(
+                            streamName, 6, credentials,
+                            function (event) {
+                                actualEventNumbers.push(event.eventNumber);
+                            },
+                            function () {
+                                assert.deepEqual(actualEventNumbers, [7, 8, 9]);
+                                done();
+                            },
+                            function () {
+                                assert.fail(null, null, 'Subscription dropped!');
+                                done();
+                            },
+                            settings);
+                    });
+            });
+        });
+    });
+
+    context('dropping basic subscription', function () {
+        it('should succeed', function (done) {
+            dbconn.open(done, function (connection) {
+                var streamName = testData.randomStreamName();
+                testStreams.push(streamName);
+
+                var settings = new EventStoreClient.CatchUpSubscription.Settings();
+
+                testData.writeEvents(
+                    connection, credentials, streamName, 10,
+                    testData.fooEvent,
+                    function () {
+                        var subscription =
+                            connection.subscribeToStreamFrom(
+                                streamName, 6, credentials,
+                                function (event) {},
+                                function () {
+                                    subscription.stop();
+                                },
+                                function () {
+                                    done();
+                                },
+                                settings);
+                    });
+            });
+        });
+
+        it('should handle it when event callback throws an error', function (done) {
+            dbconn.open(done, function (connection) {
+                var streamName = testData.randomStreamName();
+                testStreams.push(streamName);
+
+                var settings = new EventStoreClient.CatchUpSubscription.Settings();
+
+                testData.writeEvents(
+                    connection, credentials, streamName, 10,
+                    testData.fooEvent,
+                    function () {
+                        var subscription =
+                            connection.subscribeToStreamFrom(
+                                streamName, 6, credentials,
+                                function (event) { throw new Error('unable to cope with existence'); },
+                                function () {},
+                                function (subscription, reason, err) {
+                                    assert.equal(reason, 'CatchUpError');
+                                    assert.equal(err.message, 'unable to cope with existence');
+                                    done();
+                                },
+                                settings);
                     });
             });
         });

--- a/test/common.js
+++ b/test/common.js
@@ -1,0 +1,14 @@
+/***
+ * To run these tests, install Event Store on a machine, and point the alias eventstore to it, by defining it in your HOSTS file or DNS.
+ * You can test against a copy of Event Store on localhost by putting "127.0.0.1 eventstore" in your HOSTS file.
+  */
+
+(function(common) {
+
+    common.defaultHostName = "eventstore";
+    common.credentials = {
+        username: "admin",
+        password: "changeit"
+    };
+
+})(module.exports);

--- a/test/common/dbconn.js
+++ b/test/common/dbconn.js
@@ -3,10 +3,10 @@
  * You can test against a copy of Event Store on localhost by putting "127.0.0.1 eventstore" in your HOSTS file.
   */
 
-(function(common) {
+(function(dbconn) {
 
-    common.defaultHostName = "eventstore";
-    common.credentials = {
+    dbconn.defaultHostName = "eventstore";
+    dbconn.credentials = {
         username: "admin",
         password: "changeit"
     };

--- a/test/common/dbconn.js
+++ b/test/common/dbconn.js
@@ -5,10 +5,26 @@
 
 (function(dbconn) {
 
+    var EventStoreClient = require("../../index.js");
+
     dbconn.defaultHostName = "eventstore";
     dbconn.credentials = {
         username: "admin",
         password: "changeit"
+    };
+
+    dbconn.open = function (onFail, onSuccess, hostName, credentials) {
+        hostName = hostName || dbconn.defaultHostName;
+        credentials = credentials || dbconn.credentials;
+        var connectionError = null;
+
+        var options = {
+            host: hostName,
+            onError: onFail
+        };
+
+        var connection = new EventStoreClient.Connection(options);
+        if (connection) onSuccess(connection);
     };
 
 })(module.exports);

--- a/test/common/testData.js
+++ b/test/common/testData.js
@@ -1,0 +1,81 @@
+/**
+ * Utilities for creating and managing test streams and events. 
+ */
+(function (testData) {
+
+    var uuid = require('node-uuid');
+    var EventStoreClient = require("../../index.js");
+
+    /**
+     * Returns a stream name composed of the prefix "test-" and a random UUID.
+     */
+    testData.randomStreamName = function() {
+        return 'test-' + uuid.v4();
+    };
+
+    /**
+     * Creates meaningless stub Event object as filler.
+     */
+    testData.fooEvent = function() {
+        return {
+            eventId: uuid.v4(),
+            eventType: 'ThingHappened',
+            data: { foo: true }
+        };
+    }
+
+    /**
+     * Generates the specified number of Event objects and returns them as an array.
+     * 
+     * @param {number} totalEvents The number of events to generate.
+     * @param {function} getEvent Function that takes a number (i), which is the 0-based index of the event being created, and returns the Event.
+     * @returns Array of generated events. 
+     */
+    testData.generateEvents = function (totalEvents, getEvent) {
+        var events = [];
+        for (var i = 0; i < totalEvents; i++) {
+            events.push(getEvent(i));
+        }
+        return events;
+    }
+
+    /**
+     * Generates the specified number of Event objects and writes them to Event Store.
+     * 
+     * @param {Connection} connection Connection to Event Store.
+     * @param {ICredentials} credentials Credentials for writing events to Event Store.
+     * @param {string} streamName Name of stream to write to. 
+     * @param {number} totalEvents The number of events to generate.
+     * @param {function} getEvent Function that takes a number (i), which is the 0-based index of the event being created, and returns the Event.
+     * @param {function} callback Callback function for when writing events is done. 
+     * @returns Array of generated events. 
+     */
+    testData.writeEvents = function(connection, credentials, streamName, totalEvents, getEvent, callback) {
+        var events = testData.generateEvents(totalEvents, getEvent);
+        connection.writeEvents(streamName, EventStoreClient.ExpectedVersion.Any, false, events, credentials, callback);
+    };
+
+    /**
+     * Deletes the specified streams from Event Store. 
+     * SAFETY FEATURE: will only delete streams that begin with 'test-'. 
+     * 
+     * @param {Connection} connection Connection to Event Store.
+     * @param {ICredentials} credentials Credentials for writing events to Event Store.
+     * @param {array} streamNames Array of names of stream to delete. 
+     * @param {function} callback Callback function for when deleting streams is done. 
+     * @returns Array of generated events. 
+     */
+    testData.deleteTestStreams = function (connection, credentials, streamNames, callback) {
+        if (streamNames.length == 0) {
+            if (callback) callback();
+        } else {
+            connection.deleteStream(streamNames[0], EventStoreClient.ExpectedVersion.Any, false, true, credentials, function (completed) {
+                if (completed.result != 5 && completed.result != 0) {
+                    console.log('Error deleting test stream %s (%d): %s', streamNames[0], completed.result, completed.message);
+                }
+                testData.deleteTestStreams(connection, credentials, streamNames.slice(1), callback); // Delete the rest.
+            });
+        }
+    };
+
+})(module.exports);

--- a/test/connection.js
+++ b/test/connection.js
@@ -1,17 +1,10 @@
-/***
- * To run these tests, install Event Store on a machine, and point the alias eventstore to it, by defining it in your HOSTS file or DNS.
- * You can test against a copy of Event Store on localhost by putting "127.0.0.1 eventstore" in your HOSTS file.
-  */
 var assert = require("assert");
 var uuid   = require('node-uuid');
 
 var EventStoreClient = require("../index.js");
-
-var defaultHostName = "eventstore";
-var credentials = {
-    username: "admin",
-    password: "changeit"
-};
+var common = require("./common");
+var defaultHostName = common.defaultHostName;
+var credentials = common.credentials;
 
 describe('Connection', function() {
     describe('Establishing a connection', function() {

--- a/test/connection.js
+++ b/test/connection.js
@@ -2,9 +2,9 @@ var assert = require("assert");
 var uuid   = require('node-uuid');
 
 var EventStoreClient = require("../index.js");
-var common = require("./common");
-var defaultHostName = common.defaultHostName;
-var credentials = common.credentials;
+var dbconn = require("./common/dbconn");
+var defaultHostName = dbconn.defaultHostName;
+var credentials = dbconn.credentials;
 
 describe('Connection', function() {
     describe('Establishing a connection', function() {

--- a/test/connection.js
+++ b/test/connection.js
@@ -7,6 +7,7 @@ var uuid   = require('node-uuid');
 
 var EventStoreClient = require("../index.js");
 
+var defaultHostName = "eventstore";
 var credentials = {
     username: "admin",
     password: "changeit"
@@ -16,7 +17,7 @@ describe('Connection', function() {
     describe('Establishing a connection', function() {
         it('should connect successfully to eventstore', function(done) {
             var options = {
-                host: "eventstore",
+                host: defaultHostName,
                 onError: done
             };
             var connection = new EventStoreClient.Connection(options);
@@ -44,7 +45,7 @@ describe('Connection', function() {
     describe('Reading from a stream', function() {
         it("should read 10 events from the stats stream backwards", function(done) {
             var options = {
-                host: "eventstore",
+                host: defaultHostName,
                 onError: done
             };
 
@@ -72,7 +73,7 @@ describe('Connection', function() {
         });
         it("should read 10 events from the stats stream forwards", function(done) {
             var options = {
-                host: "eventstore",
+                host: defaultHostName,
                 onError: done
             };
 
@@ -103,7 +104,7 @@ describe('Connection', function() {
     describe('Writing to a stream', function() {
         it("should be able to write 1 event with a binary GUID to the end of the stream", function(done) {
             var options = {
-                host: "eventstore",
+                host: defaultHostName,
                 onError: done
             };
 
@@ -130,7 +131,7 @@ describe('Connection', function() {
         });
         it("should be able to write 1 event with a hex GUID to the end of the stream", function(done) {
             var options = {
-                host: "eventstore",
+                host: defaultHostName,
                 onError: done
             };
 
@@ -158,7 +159,7 @@ describe('Connection', function() {
 
         it("should be able to write 1 event with a braced hex GUID to the end of the stream", function(done) {
             var options = {
-                host: "eventstore",
+                host: defaultHostName,
                 onError: done
             };
 


### PR DESCRIPTION
Pertaining to issue #3, I have ported the catch-up subscription functionality from the official Event Store .NET client. 

As of now only single-stream catch-up subscriptions are implemented, not all-event catch-up subscriptions, primarily because the `subscribeToAll` functionality seems to be missing from the Connection class. As I don't need subscribe-to-all right now, I've chosen not to implement it for this pull request. 

I added one (tiny) additional package: the `argument-validator` package - just for some quick argument validation.  That package has no dependencies of its own; it's very lightweight. 

In addition to the new code, I have updated the README file and the TypeScript definitions. 

There are some new Mocha tests in the testing area, all working on a bare-bones installation of Event Store. The tests create and destroy randomly named streams. As part of adding the new test code, I've centralized some of the common test functionality and adding quick utilities for generating and writing test events. 
