### PR TITLE
[Fix] allow reading of resolved linked to events where event is null

### DIFF
--- a/ClientMessageDtos.proto
+++ b/ClientMessageDtos.proto
@@ -35,7 +35,7 @@ message EventRecord {
 }
 
 message ResolvedIndexedEvent {
-	required EventRecord event = 1;
+	optional EventRecord event = 1;
 	optional EventRecord link = 2;
 }
 

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -509,10 +509,12 @@ function unpackResolvedEvent(resolvedEvent) {
     if (!resolvedEvent) {
         return null;
     }
-    if (!resolvedEvent.event) {
-        throw new Error("Not a ResolvedEvent: " + resolvedEvent);
+
+    var unpackedEvent = {};
+    if (resolvedEvent.event) {
+        unpackedEvent = unpackEventRecord(resolvedEvent.event);
     }
-    var unpackedEvent = unpackEventRecord(resolvedEvent.event);
+
     if (resolvedEvent.link) unpackedEvent.link = unpackEventRecord(resolvedEvent.link);
     return unpackedEvent;
 }


### PR DESCRIPTION
When reading a projected stream, if the source event has been removed, the link event still exists inside the projected stream. This causes the resolved event to be returned as null from event store itself causing an exception that the event field is required.
