### PR TITLE
Issue #1 - Metadata - read and write binary and JSON metadata on events

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Represents an event either before or after it has been stored.
 * eventId - A GUID uniquely identifying this event (string)
 * eventType - The type of event (string)
 * data - An object to be JSON-serialized as the data for the event (object, optional)
+* metadata - An object to be JSON-serialized as the metadata for the event (object, optional)
 
 ## StoredEvent class
 Represents an event as it exists on the Event Store server. Inherits from Event and adds the following properties:

--- a/event-store-client.d.ts
+++ b/event-store-client.d.ts
@@ -60,6 +60,7 @@ declare module "event-store-client" {
 		eventId: string;
 		eventType: string;
 		data: any;
+		metadata: any;
 	}
 
 	export interface StoredEvent extends Event {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -365,20 +365,21 @@ Connection.prototype.readStreamEventsForward = function(streamId, fromEventNumbe
 Connection.prototype.writeEvents = function(streamId, expectedVersion, requireMaster, events, credentials, callback) {
     // Convert the data into the format required for the message
     for(var i=0; i<events.length; i++) {
-        if (!events[i]) {
+        var event = events[i];
+        if (!event) {
             throw new Error("Event " + i + " is undefined or null");
         }
 
         // Ensure that the event has an eventId GUID in the right format
-        if (events[i].eventId) {
-            if (typeof events[i].eventId == "string") {
+        if (event.eventId) {
+            if (typeof event.eventId == "string") {
                 // GUID has been supplied as a hex string, convert it to a buffer
-                var hex = events[i].eventId.replace(/[^0-9a-fA-F]/g, "");
+                var hex = event.eventId.replace(/[^0-9a-fA-F]/g, "");
                 if (hex.length != 32) {
                     throw new Error("Event " + i + " does not have a valid GUID for eventId: " + hex);
                 }
-                events[i].eventId = new Buffer(hex, "hex");
-            } else if (!Buffer.isBuffer(events[i].eventId)) {
+                event.eventId = new Buffer(hex, "hex");
+            } else if (!Buffer.isBuffer(event.eventId)) {
                 // GUID is not a string or a Buffer
                 throw new Error("Event " + i + " does not have a valid eventId. Expected a string or a Buffer.");
             }
@@ -387,23 +388,35 @@ Connection.prototype.writeEvents = function(streamId, expectedVersion, requireMa
         }
 
         // Update the metadata for the event based on the supplied data
-        if (events[i].data) {
-            if (Buffer.isBuffer(events[i].data)) {
+        if (event.data) {
+            if (Buffer.isBuffer(event.data)) {
                 // Binary data
-                events[i].dataContentType = 0;
+                event.dataContentType = 0;
             } else {
                 // JSON encode the nested objects
-                events[i].dataContentType = 1;
-                var json = JSON.stringify(events[i].data);
-                events[i].data = new Buffer(json);
+                event.dataContentType = 1;
+                var json = JSON.stringify(event.data);
+                event.data = new Buffer(json);
             }
         } else {
-            events[i].dataContentType = 0;
-            events[i].data = [];
+            event.dataContentType = 0;
+            event.data = [];
         }
 
-        events[i].metadataContentType = 0;
-        events[i].metadata = null;
+        if (event.metadata) {            
+            if (Buffer.isBuffer(event.metadata)) {
+                // Binary metadata
+                event.metadataContentType = 0;
+            } else {
+                // JSON encode the nested objects
+                event.metadataContentType = 1;
+                var json = JSON.stringify(event.metadata);
+                event.metadata = new Buffer(json);
+            }
+        } else {
+            event.metadataContentType = 0;
+            event.metadata = null;
+        }
     }
 
     var writeEvents = new Messages.WriteEvents();
@@ -560,7 +573,7 @@ function unpackEventRecord(eventRecord) {
     var data = eventRecord.data.toBuffer();
     if (!data) {
         event.data = null;
-    } else if (eventRecord.dataContentType == 1) {
+    } else if (eventRecord.dataContentType === 1) {
         // alternatively check for open curly brace (data[0] == 0x7B)
         // JSON
         event.data = JSON.parse(data.toString());
@@ -570,7 +583,26 @@ function unpackEventRecord(eventRecord) {
         event.data = data;
         event.dataHex = data.toString('hex');
     }
+
+    event.metadata = parseMetadata(eventRecord);
+
     return event;
+}
+
+function parseMetadata(eventRecord) {
+    var metadata = eventRecord.metadata.toBuffer();
+    if (metadata.length === 0) {
+        return null;
+    } 
+
+    // Metadata may be JSON or binary - EventStore does not honour the metadata_content_type field,
+    // and will set it to the same value as the data_content_type field.
+    try {
+        var json = JSON.parse(metadata.toString());
+        return json
+    } catch (err) {
+        return metadata
+    }        
 }
 
 /***

--- a/test/metadata/binaryEventMetadata.js
+++ b/test/metadata/binaryEventMetadata.js
@@ -1,0 +1,56 @@
+var assert = require("assert");
+var EventStoreClient = require("../../index.js");
+var dbconn = require("../common/dbconn");
+
+var defaultHostName = dbconn.defaultHostName;
+var credentials = dbconn.credentials;
+
+var streamId = "event-store-client-test";
+
+describe("Binary Event Metadata", function() {
+    describe("Reading binary metadata from an event", function() {
+
+        var testEventNumber = null;
+        var testRunDate = new Date().toISOString();
+        
+        before("Write a test event with binary metadata", function(done) {
+            var events = [{
+                eventId: EventStoreClient.Connection.createGuid(),
+                eventType: "MetadataTestEvent",
+                data: new Buffer("Testing reading and writing event metadata"),
+                metadata: new Buffer(testRunDate)
+            }];
+
+            var connection = new EventStoreClient.Connection({ host: defaultHostName, onError: done });
+            connection.writeEvents(streamId, EventStoreClient.ExpectedVersion.Any, false, events, credentials, function(completed) {
+                testEventNumber = completed.firstEventNumber;
+                connection.close();
+                done();
+            });            
+        });
+
+        it("should have binary metadata on the event", function(done) {
+            var testEvent = null;
+            var readSingleEvent = 1;    
+
+            var connection = new EventStoreClient.Connection({ host: defaultHostName, onError: done });
+            connection.readStreamEventsBackward(streamId, testEventNumber, readSingleEvent, false, false, onEventAppeared, credentials, onCompleted);
+
+            function onEventAppeared(event) { testEvent = event; }
+
+            function onCompleted(completed) {
+                assert.equal(completed.result, EventStoreClient.ReadStreamResult.Success,
+                    "Expected a result code of Success, not " + EventStoreClient.ReadStreamResult.getName(completed.result));
+
+                assert.ok(testEvent.isJson === false, 
+                    "Expected event to have JSON data");
+
+                assert.equal(testRunDate, testEvent.metadata.toString(),
+                    "Expected metadata field 'testRanAt' to match date " + testRunDate);
+
+                connection.close();
+                done();
+            }
+        });
+    });
+});

--- a/test/metadata/jsonEventMetadata.js
+++ b/test/metadata/jsonEventMetadata.js
@@ -1,0 +1,56 @@
+var assert = require("assert");
+var EventStoreClient = require("../../index.js");
+var dbconn = require("../common/dbconn");
+
+var defaultHostName = dbconn.defaultHostName;
+var credentials = dbconn.credentials;
+
+var streamId = "event-store-client-test";
+
+describe("JSON Event Metadata", function() {
+	describe("Reading JSON metadata from an event", function() {
+
+		var testEventNumber = null;
+		var testRunDate = new Date().toISOString();
+
+		before("Writing a test event with metadata", function(done) {
+			var events = [{
+                eventId: EventStoreClient.Connection.createGuid(),
+                eventType: "MetadataTestEvent",
+                data: { comment: "Testing reading and writing event metadata" },
+                metadata: { testRanAt: testRunDate }
+            }];
+
+            var connection = new EventStoreClient.Connection({ host: defaultHostName, onError: done });
+            connection.writeEvents(streamId, EventStoreClient.ExpectedVersion.Any, false, events, credentials, function(completed) {
+                testEventNumber = completed.firstEventNumber;
+                connection.close();
+                done();
+            });             
+		});
+		
+		it("should have JSON metadata defined on the event", function(done) {
+			var testEvent = null;
+            var readSingleEvent = 1;    
+
+            var connection = new EventStoreClient.Connection({ host: defaultHostName, onError: done });
+            connection.readStreamEventsBackward(streamId, testEventNumber, readSingleEvent, false, false, onEventAppeared, credentials, onCompleted);
+
+            function onEventAppeared(event) { testEvent = event; }
+
+			function onCompleted(completed) {
+				assert.equal(completed.result, EventStoreClient.ReadStreamResult.Success,
+					"Expected a result code of Success, not " + EventStoreClient.ReadStreamResult.getName(completed.result));
+
+				assert.ok(testEvent.isJson === true, 
+					"Expected event to have JSON data");
+
+				assert.equal(testRunDate, testEvent.metadata.testRanAt,
+					"Expected metadata field 'testRanAt' to match date " + testRunDate);
+
+				connection.close();
+				done();
+			};
+		});
+	});
+});

--- a/test/metadata/mixedBinaryAndJson.js
+++ b/test/metadata/mixedBinaryAndJson.js
@@ -1,0 +1,114 @@
+var assert = require("assert");
+var EventStoreClient = require("../../index.js");
+var dbconn = require("../common/dbconn");
+
+var defaultHostName = dbconn.defaultHostName;
+var credentials = dbconn.credentials;
+
+var streamId = "event-store-client-test";
+
+describe("Mixed Event Data and Metadata Types", function() {
+	describe("Reading an event with JSON data and binary metadata", function() {
+
+		var testEventNumber = null;
+		var testRunDate = new Date().toISOString();
+
+		var data = { comment: "Testing reading and writing event metadata" }
+		var metadata = new Buffer(testRunDate)
+
+		before("Write a test event with binary metadata", function(done) {
+			var events = [{
+				eventId: EventStoreClient.Connection.createGuid(),
+				eventType: "MetadataTestEvent",
+				data: data,
+				metadata: metadata
+			}];
+
+			var connection = new EventStoreClient.Connection({ host: defaultHostName, onError: done });
+			connection.writeEvents(streamId, EventStoreClient.ExpectedVersion.Any, false, events, credentials, function(completed) {
+				testEventNumber = completed.firstEventNumber;
+				connection.close();
+				done();
+			});            
+		});
+
+		it("should parse binary and JSON values correctly", function(done) {
+			var testEvent = null;
+			var readSingleEvent = 1;    
+
+			var connection = new EventStoreClient.Connection({ host: defaultHostName, onError: done });
+			connection.readStreamEventsBackward(streamId, testEventNumber, readSingleEvent, false, false, onEventAppeared, credentials, onCompleted);
+
+			function onEventAppeared(event) { testEvent = event; }
+
+			function onCompleted(completed) {
+				assert.equal(completed.result, EventStoreClient.ReadStreamResult.Success,
+					"Expected a result code of Success, not " + EventStoreClient.ReadStreamResult.getName(completed.result));
+
+				assert.ok(testEvent.isJson === true, 
+					"Expected event to have JSON data");
+
+				assert.equal(data.comment, testEvent.data.comment,
+					"Expected data field 'comment' to match string " + data.comment)
+
+				assert.equal(testRunDate, testEvent.metadata,
+					"Expected metadata field 'testRanAt' to match date " + testRunDate);
+
+				connection.close();
+				done();
+			}
+		});
+	});
+
+	describe("Reading an event with binary data and JSON metadata", function() {
+
+		var testEventNumber = null;
+		var testRunDate = new Date().toISOString();
+
+		var data = new Buffer("Testing reading and writing event metadata")
+		var metadata = { testRanAt: testRunDate }
+
+		before("Write a test event with binary metadata", function(done) {
+			var events = [{
+				eventId: EventStoreClient.Connection.createGuid(),
+				eventType: "MetadataTestEvent",
+				data: data,
+				metadata: metadata
+			}];
+
+			var connection = new EventStoreClient.Connection({ host: defaultHostName, onError: done });
+			connection.writeEvents(streamId, EventStoreClient.ExpectedVersion.Any, false, events, credentials, function(completed) {
+				testEventNumber = completed.firstEventNumber;
+				connection.close();
+				done();
+			});            
+		});
+
+		it("should parse binary and JSON values correctly", function(done) {
+			var testEvent = null;
+			var readSingleEvent = 1;    
+
+			var connection = new EventStoreClient.Connection({ host: defaultHostName, onError: done });
+			connection.readStreamEventsBackward(streamId, testEventNumber, readSingleEvent, false, false, onEventAppeared, credentials, onCompleted);
+
+			function onEventAppeared(event) { testEvent = event; }
+
+			function onCompleted(completed) {
+				assert.equal(completed.result, EventStoreClient.ReadStreamResult.Success,
+					"Expected a result code of Success, not " + EventStoreClient.ReadStreamResult.getName(completed.result));
+
+				assert.ok(testEvent.isJson === false, 
+					"Expected event to have binary data");
+				
+				assert.equal(data, testEvent.data.toString(),
+					"Expected data to match string " + data)
+
+				assert.equal(testRunDate, testEvent.metadata.testRanAt,
+					"Expected metadata field 'testRanAt' to match date " + testRunDate);
+
+				connection.close();
+				done();
+			}
+		});
+	});
+});

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,1 @@
+--recursive


### PR DESCRIPTION
This PR should partly address issue #1 - binary and JSON metadata can now be written to and read from an event's metadata field.

The tests provide examples of writing events with metadata and reading that metadata back.

Interestingly, despite metadata_content_type being a field in the protobuf, when reading events out of EventStore metadata_content_type will match data_content_type, regardless of what was written.  I've included a test to highlight the behaviour in this edge case.  The metadata is unaffected- just the content type field can't be trusted in this case.

This PR only covers event metadata - stream metadata is not implemented.
