### PR TITLE
Fixes Illegal value for NewEvent.data

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -407,7 +407,7 @@ Connection.prototype.writeEvents = function(streamId, expectedVersion, requireMa
             }
         } else {
             event.dataContentType = 0;
-            event.data = [];
+            event.data = "";
         }
 
         if (event.metadata) {


### PR DESCRIPTION
When providing empty string as an event data `{..."data": "",...}` it currently throws `Error: Illegal value for Message.Field .EventStore.Client.Messages.NewEvent.data of type bytes: object (no array expected) `.