### PR TITLE
Fix reading malformed json record

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -407,7 +407,7 @@ Connection.prototype.writeEvents = function(streamId, expectedVersion, requireMa
             }
         } else {
             event.dataContentType = 0;
-            event.data = [];
+            event.data = "";
         }
 
         if (event.metadata) {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -583,8 +583,14 @@ function unpackEventRecord(eventRecord) {
     } else if (eventRecord.dataContentType === 1) {
         // alternatively check for open curly brace (data[0] == 0x7B)
         // JSON
-        event.data = JSON.parse(data.toString());
-        event.isJson = true;
+        try {
+            event.data = JSON.parse(data.toString());
+            event.isJson = true;
+        } catch (e) {
+            // Fallback to Binary if JSON cannot be decoded
+            event.data = data;
+            event.dataHex = data.toString('hex');
+        }
     } else {
         // Binary
         event.data = data;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -209,6 +209,20 @@ Connection.createGuid = function() {
     return buffer;
 };
 
+/**
+ * Converts uuid to wtf version.
+ * Any UUID sent to GetEventStore needs to be converted to wtf uuid
+ */
+Connection.prototype.convertUuidToWtf = function(uuid) {
+    var hex = uuid.replace(/-/g, '');
+    var guid = hex.substring(6, 8) + hex.substring(4, 6) + hex.substring(2, 4) + hex.substring(0, 2) + "-" +
+        hex.substring(10, 12) + hex.substring(8, 10) + "-" +
+        hex.substring(14, 16) + hex.substring(12, 14) + "-" +
+        hex.substring(16, 20) + "-" +
+        hex.substring(20);
+    return guid;
+};
+
 /***
  * Sends a ping to the server and expects a pong response
  * @param callback Invoked when the corresponding pong is received from the server
@@ -381,7 +395,7 @@ Connection.prototype.writeEvents = function(streamId, expectedVersion, requireMa
         if (event.eventId) {
             if (typeof event.eventId == "string") {
                 // GUID has been supplied as a hex string, convert it to a buffer
-                var hex = event.eventId.replace(/[^0-9a-fA-F]/g, "");
+                var hex = this.convertUuidToWtf(event.eventId).replace(/-/g, '');
                 if (hex.length != 32) {
                     throw new Error("Event " + i + " does not have a valid GUID for eventId: " + hex);
                 }

--- a/test/metadata/mixedBinaryAndJson.js
+++ b/test/metadata/mixedBinaryAndJson.js
@@ -140,7 +140,7 @@ describe("Mixed Event Data and Metadata Types", function() {
 			var readSingleEvent = 1;
 
 			var connection = new EventStoreClient.Connection({ host: defaultHostName, onError: done });
-			connection.readStreamEventsBackward(streamId, testEventNumber, readSingleEvent, false, false, onEventAppeared, credentials, onCompleted);
+			connection.readStreamEventsBackward(streamId, testEventNumber, readSingleEvent, true, false, onEventAppeared, credentials, onCompleted);
 
 			function onEventAppeared(event) { testEvent = event; }
 


### PR DESCRIPTION
Seems like eventRecord.dataContentType === 1 is not reliable to check whether data is JSON valid.

(I have some events in EventStore written by API calls which have empty data, but dataContentType=1)