### PR TITLE
Migrate from deprecated node-uuid to uuid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .idea/
 node_modules/
 config.json
+package-lock.json
 npm-debug.log

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,5 +1,5 @@
-var net                 = require("net");
-var uuid                = require('node-uuid');
+var net                   = require("net");
+var uuidv4                = require('uuid/v4');
 
 var CatchUpSubscription = require("./catchUpSubscription");
 var Messages            = require("./messages");
@@ -205,7 +205,7 @@ Connection.prototype.close = function() {
  */
 Connection.createGuid = function() {
     var buffer = new Buffer(GUID_LENGTH);
-    uuid.v4({}, buffer);
+    uuidv4({}, buffer);
     return buffer;
 };
 

--- a/package.json
+++ b/package.json
@@ -5,16 +5,17 @@
   "author": "Carey Bishop",
   "license": "BSD-2-Clause",
   "types": "./event-store-client.d.ts",
-  "repository" : {
-    "type" : "git",
-    "url" : "http://github.com/x-cubed/event-store-client.git"
+  "repository": {
+    "type": "git",
+    "url": "http://github.com/x-cubed/event-store-client.git"
   },
   "main": "index.js",
   "dependencies": {
-    "protobufjs": "~5.0.1",
-    "node-uuid": "~1.4.1",
+    "argument-validator": "^0.1.0",
     "long": "~3.1.0",
-    "argument-validator": "^0.1.0"
+    "protobufjs": "~5.0.1",
+    "uuid": "^3.2.1",
+    "uuid-parse": "^1.0.0"
   },
   "devDependencies": {
     "mocha-teamcity-reporter": "~1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,13 +14,13 @@
     "argument-validator": "^0.1.0",
     "long": "~3.1.0",
     "protobufjs": "~5.0.1",
-    "uuid": "^3.2.1",
-    "uuid-parse": "^1.0.0"
+    "uuid": "^3.2.1"
   },
   "devDependencies": {
+    "mocha": "~2.5.3",
     "mocha-teamcity-reporter": "~1.0.0",
     "optimist": "~0.6.1",
-    "mocha": "~2.5.3"
+    "uuid-parse": "^1.0.0"
   },
   "scripts": {
     "test": "mocha",

--- a/test/common/testData.js
+++ b/test/common/testData.js
@@ -3,14 +3,14 @@
  */
 (function (testData) {
 
-    var uuid = require('node-uuid');
+    var uuidv4 = require('uuid/v4');
     var EventStoreClient = require("../../index.js");
 
     /**
      * Returns a stream name composed of the prefix "test-" and a random UUID.
      */
     testData.randomStreamName = function() {
-        return 'test-' + uuid.v4();
+        return 'test-' + uuidv4();
     };
 
     /**
@@ -18,7 +18,7 @@
      */
     testData.fooEvent = function() {
         return {
-            eventId: uuid.v4(),
+            eventId: uuidv4(),
             eventType: 'ThingHappened',
             data: { foo: true }
         };

--- a/test/connection.js
+++ b/test/connection.js
@@ -1,5 +1,5 @@
-var assert = require("assert");
-var uuid   = require('node-uuid');
+var assert    =  require("assert");
+var uuidParse = require('uuid-parse')
 
 var EventStoreClient = require("../index.js");
 var dbconn = require("./common/dbconn");
@@ -175,7 +175,7 @@ describe('Connection', function() {
             var expectedVersion = EventStoreClient.ExpectedVersion.Any;
             var requireMaster = false;
             var events = [{
-                eventId: uuid.unparse(EventStoreClient.Connection.createGuid()),
+                eventId: uuidParse.unparse(EventStoreClient.Connection.createGuid()),
                 eventType: "TestEvent",
                 data: {
                     testRanAt: new Date().toISOString()


### PR DESCRIPTION
Fix `uuid` deprecation issues:

* `node-uuid` package is deprecated and should be changed to `uuid`
* Usage of `require('node-uuid')` (and `require('uuid')`) is deprecated. Instead, use `require('uuid/[v1|v3|v4|v5]')`
* `parse` and `unparse` functions were moved to the separate package (and are used as dev-dependencies only)